### PR TITLE
Update version to 0.4.0-SNAPSHOT and migrate snapshot repository to Central Portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ repositories {
     mavenCentral()
     // If you want to use the latest snapshot version.
     maven {
-        url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots")
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         mavenContent {
             snapshotsOnly()
             includeGroup("io.github.kubode.compose.shadow")

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ android.useAndroidX=true
 #kotlin.experimental.tryK2=true
 # Publilshing
 group=io.github.kubode.compose.shadow
-version=0.3.0-SNAPSHOT
+version=0.4.0-SNAPSHOT
 # https://vanniktech.github.io/gradle-maven-publish-plugin/central/
 SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=true


### PR DESCRIPTION
## 🎯 Purpose
Updates the project to version 0.4.0-SNAPSHOT and migrates snapshot repository to Central Publisher Portal.

## 🔧 Changes Made

### Version Update
- **gradle.properties**: Updated version from `0.3.0-SNAPSHOT` to `0.4.0-SNAPSHOT`

### Snapshot Repository Migration  
- **README.md**: Updated snapshot repository URI to align with Central Publisher Portal migration
  - Changed from: `https://s01.oss.sonatype.org/content/repositories/snapshots`
  - Changed to: `https://central.sonatype.com/repository/maven-snapshots/`

## ✅ Testing Status
- [x] Build verification passed
- [x] Repository URI updated correctly
- [x] Based on latest main branch with Central Portal migration

## 📋 Notes
This PR builds upon the previous Central Publisher Portal migration and prepares the project for the next minor version release. The snapshot repository change ensures users can continue accessing development versions through the new Central Portal infrastructure.

## 🚨 Dependencies
Requires namespace `io.github.kubode.compose.shadow` to have snapshots enabled in Central Publisher Portal before snapshot publishing will work. 